### PR TITLE
fix: restore correct boolean comparison for isActive field in database

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -180,7 +180,7 @@ export class PrismDatabase extends Dexie {
       const allFiles = await this.fileMetadata.toArray();
       console.log('[DATABASE] All files in database:', allFiles);
       
-      const query = this.fileMetadata.where('isActive').equals(1);
+      const query = this.fileMetadata.where('isActive').equals(true as any);
       
       if (fileType) {
         const result = await query.and(file => file.fileType === fileType).first();


### PR DESCRIPTION
Fixed critical bug where isActive field comparison was changed from equals(true) to equals(1), breaking file retrieval. The isActive field is stored as a boolean, not a number, so it must be compared with true.

This restores the ability to view uploaded files in the application.

🤖 Generated with [Claude Code](https://claude.ai/code)